### PR TITLE
Dockerize ollama3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Repository for Open-Chat (tentative), an application that allows users to serve 
 Workflow:
 
 1. cd /backend
-2. make pull-image
-3. make run
-4. make pull-model
+2. `make pull-image`
+3. `make run`
+4. `make pull-model`
 This will leave you in a prompt window in terminal 
     - to exit terminal prompt: `ctrl+d` 
 
-to run a test from the makefile via curl you can update the prompt in the makefile and run
-- make test 
+to run a test from the makefile via curl you can update the prompt variable in the makefile and run
+- `make test` 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,3 @@ This will leave you in a prompt window in terminal
 
 to run a test from the makefile via curl you can update the prompt in the makefile and run
 - make test 
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # open-chat
 
 Repository for Open-Chat (tentative), an application that allows users to serve ollama models offline.
+
+Workflow:
+
+1. cd /backend
+2. make pull-image
+3. make run
+4. make pull-model
+This will leave you in a prompt window in terminal 
+    - to exit terminal prompt: `ctrl+d` 
+
+to run a test from the makefile via curl you can update the prompt in the makefile and run
+- make test 
+
+
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine/llama3.2
+
+ENV OLLAMA_MODELS=/root/.ollama
+
+# Ollama default port
+EXPOSE 11434
+
+# Start the Ollama server
+CMD ["ollama", "serve"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,8 +15,8 @@ run:
 		-v ollama_data:/root/.ollama \
 		$(IMAGE_NAME)
 
-# leaves the terminal open in a usable prompt
-# pull-model:
+# pulls the model and leaves the terminal open in a usable prompt, leaving this commented out for now because its not that useful unless you want to have a terminal window consumed by this. It will probably get removed in the future, but this is what I was initially using to test this. 
+# pull-model-prompt:
 # 	docker exec -it $(CONTAINER_NAME) ollama run $(MODEL_NAME)
 
 # pulls the model but does not leave it running in the terminal
@@ -53,7 +53,7 @@ test:
 # stops the container and removes it
 stop:
 	docker stop $(CONTAINER_NAME) || true
-	docker rm $(CONTAINER_NAME) || truee
+	docker rm $(CONTAINER_NAME) || true
 
 # runs make stop then removes the volume
 clean: stop

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,31 @@
+IMAGE_NAME=alpine/llama3.2
+CONTAINER_NAME=ollama3.2
+MODEL_NAME=llama3.2
+
+.PHONY: pull-image run pull-model test stop clean
+
+pull-image:
+	docker pull $(IMAGE_NAME)
+
+run:
+	docker run -d \
+		--name $(CONTAINER_NAME) \
+		-p 11434:11434 \
+		-v ollama_data:/root/.ollama \
+		$(IMAGE_NAME)
+
+pull-model:
+	docker exec -it $(CONTAINER_NAME) ollama run $(MODEL_NAME)
+
+test:
+	curl -s http://localhost:11434/api/generate \
+	  -H "Content-Type: application/json" \
+	  -d '{"model": "$(MODEL_NAME)", "prompt": "What is software?", "stream": false}' | jq -r '.response'
+
+
+stop:
+	docker stop $(CONTAINER_NAME) || true
+	docker rm $(CONTAINER_NAME) || truee
+
+clean: stop
+	docker volume rm ollama_data || true

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,8 +1,9 @@
 IMAGE_NAME=alpine/llama3.2
 CONTAINER_NAME=ollama3.2
 MODEL_NAME=llama3.2
+PROMPT="What is software?"
 
-.PHONY: pull-image run pull-model test stop clean
+.PHONY: pull-image run pull-model chat test stop clean
 
 pull-image:
 	docker pull $(IMAGE_NAME)
@@ -14,18 +15,46 @@ run:
 		-v ollama_data:/root/.ollama \
 		$(IMAGE_NAME)
 
+# leaves the terminal open in a usable prompt
+# pull-model:
+# 	docker exec -it $(CONTAINER_NAME) ollama run $(MODEL_NAME)
+
+# pulls the model but does not leave it running in the terminal
 pull-model:
+	docker exec $(CONTAINER_NAME) ollama pull $(MODEL_NAME)
+
+# allows you to exec into the container and run a chat in terminal
+chat:
 	docker exec -it $(CONTAINER_NAME) ollama run $(MODEL_NAME)
 
+# runs a test query against the model (Ollama) and will stream the response to the terminal. replace prompt variable at the top with a string with your own
 test:
-	curl -s http://localhost:11434/api/generate \
+	@echo "Waiting for Ollama to be ready..."
+	@counter=0; \
+	until curl -s -f http://localhost:11434 | grep -q "Ollama is running"; do \
+		if [ $$counter -ge 15 ]; then \
+			echo "Ollama not ready after 30 seconds."; \
+			exit 1; \
+		fi; \
+		echo "Waiting..."; \
+		sleep 2; \
+		counter=$$((counter + 1)); \
+	done; \
+	echo "Ollama is ready. Streaming response..."; \
+	curl -Ns http://localhost:11434/api/generate \
 	  -H "Content-Type: application/json" \
-	  -d '{"model": "$(MODEL_NAME)", "prompt": "What is software?", "stream": false}' | jq -r '.response'
+	  -d '{"model": "$(MODEL_NAME)", "prompt": $(PROMPT), "stream": true}' \
+	  | jq -rc --unbuffered 'select(.response) | .response' \
+	  | while IFS= read -r token; do \
+	      printf "%s" "$$token"; \
+	    done; \
+	echo ""
 
-
+# stops the container and removes it
 stop:
 	docker stop $(CONTAINER_NAME) || true
 	docker rm $(CONTAINER_NAME) || truee
 
+# runs make stop then removes the volume
 clean: stop
 	docker volume rm ollama_data || true


### PR DESCRIPTION
Adds a basic makefile and ollama3.2 dockerfile setup with commands to ..

pull the Ollama image:
- `make pull-image`
___
run the container:
- `make run`
___
pull the model:
- `make pull-model`
___
run a test query via a curl request to ollama api:
- `make test`
___

Im not even sure if this is the direction we want to go, I tried setting up [llama.cpp](https://github.com/ggml-org/llama.cpp) and ran into some complexities and quite large overhead so I abandoned that for now. 

Once we are a bit more clear on direction of this project and our target deployments along with some additional research this can be changed out. 

